### PR TITLE
尝试修复pre_release的工作流

### DIFF
--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -2,10 +2,11 @@ name: Android CI
 
 on:
   push:
-    tags-ignore:
-      - 'v*'
     branches:
-      - '*'
+      - "*"
+    tags:
+      - "*"
+      - "!v*"
   pull_request:
 
 jobs:
@@ -51,7 +52,7 @@ jobs:
           echo ${{ secrets.GRADLE_PROPERTIES}} | base64 --decode >> gradle.properties
 
       - name: Build with Gradle
-        run: ./gradlew assembleDebug assembleRelease
+        run: ./gradlew :app:assembleRelease
 
       - name: Upload Artifact (Release)
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- 重命名了ci.yml文件，使之更易懂
- 更改了与release版本的避让逻辑，由于上一次似乎没有正确避让
- 移除了debug的发布，由于上一次失败疑似缺少debug签名，选择同步release构建操作